### PR TITLE
Fix: Add lsb-release package to fix Trivy installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install necessary packages for all challenge levels
-RUN apt-get update && apt-get install -y --no-install-recommends openssh-server python3 python3-pip sudo curl wget rsync util-linux iproute2 ufw apache2 lvm2 nfs-kernel-server strace apparmor-utils bridge-utils gpg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends lsb-release openssh-server python3 python3-pip sudo curl wget rsync util-linux iproute2 ufw apache2 lvm2 nfs-kernel-server strace apparmor-utils bridge-utils gpg && rm -rf /var/lib/apt/lists/*
 
 # Install Trivy for Senior challenge
 RUN wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | tee /usr/share/keyrings/trivy.gpg > /dev/null


### PR DESCRIPTION
This commit resolves a persistent Docker build failure that occurred during the installation of Trivy.

The root cause of the error was the absence of the `lsb-release` package. The command `lsb_release -sc`, used to determine the Ubuntu release codename (e.g., "jammy"), was failing silently, leading to a malformed entry in the apt sources list for the Trivy repository.

By adding `lsb-release` to the main `apt-get install` command, the script now correctly identifies the distribution codename, allowing the Trivy repository to be added successfully and the build to complete.