### PR TITLE
I have fixed the Trivy installation in the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends lsb-release ope
 
 # Install Trivy for Senior challenge
 RUN wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | tee /usr/share/keyrings/trivy.gpg > /dev/null
-RUN echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/trivy.list
+RUN echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | tee /etc/apt/sources.list.d/trivy.list
 RUN apt-get update && apt-get install -y trivy
 
 # Install Flask


### PR DESCRIPTION
The previous command used `lsb_release -sc` to get the distribution codename, which caused a malformed entry in the apt sources list. I replaced it with `generic` as per the official Trivy documentation, which resolves the build error.